### PR TITLE
Fix Bun installation in `start.sh`

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -26,14 +26,8 @@ install_bun() {
     else
         echo "Installing Bun..."
         curl -fsSL https://bun.sh/install | bash
-        
-        # Source the shell profile to make bun available
-        if [[ -f ~/.bashrc ]]; then
-            source ~/.bashrc
-        elif [[ -f ~/.zshrc ]]; then
-            source ~/.zshrc
-        fi
-        
+        # Set PATH to include Bun’s binary directory
+        export PATH="$HOME/.bun/bin:$PATH"
         echo "Bun installed successfully!"
     fi
 }


### PR DESCRIPTION
In the `start.sh` script where the `bun` command was unavailable after installation, causing failures in `bun install` and `bun run build`. The problem occurred because sourcing `~/.bashrc` in a non-interactive shell didn’t update the `PATH` as intended.

* Updated the script to directly set `PATH="$HOME/.bun/bin:$PATH"` after installing Bun

