### PR TITLE
Fix Bun installation checksum in wallet-generator.sh

### DIFF
--- a/wallet-generator.sh
+++ b/wallet-generator.sh
@@ -6,7 +6,7 @@ REPO_OWNER="octra-labs"
 REPO_NAME="wallet-gen"
 INSTALL_DIR="$HOME/.octra"
 TEMP_DIR="/tmp/octra-wallet-gen-install"
-BUN_INSTALL_CHECKSUM="144adba33c737330a081689ea5dd54c693c25d2bdb87b1f2d6aaed3c93de737e"
+BUN_INSTALL_CHECKSUM="7713fe768665f07a90fd7ac5eb25c9e8838703a560ba7ad942bdcedd92dc115b"
 
 echo "=== ⚠️  SECURITY WARNING ⚠️  ==="
 echo ""


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The Bun installation script in `wallet-generator.sh` was failing due to an outdated checksum value, causing the wallet generator installation to fail with: ### Root Cause
The checksum value for `https://bun.sh/install` was outdated:
- **Old checksum:** `144adba33c737330a081689ea5dd54c693c25d2bdb87b1f2d6aaed3c93de737e`
- **New checksum:** `7713fe768665f07a90fd7ac5eb25c9e8838703a560ba7ad942bdcedd92dc115b`

### Solution
Updated the `BUN_INSTALL_CHECKSUM` variable in `wallet-generator.sh` with the current checksum value.

### Testing
- ✅ Verified the new checksum matches the current Bun install script
- ✅ Tested the installation process locally - works correctly
- ✅ Bun installation, dependency installation, and wallet generator build all successful

### Files Changed
- `wallet-generator.sh` - Updated Bun install checksum